### PR TITLE
remove copy:image task

### DIFF
--- a/project/tasks/service.server.js
+++ b/project/tasks/service.server.js
@@ -35,7 +35,6 @@
         };
       };
 
-      options.files.push(buildWatcher(['./source/images/**/*.{png|jpg|gif}'], 'copy:image'));
       options.files.push(buildWatcher($.path.app, 'js:process'));
       options.files.push(buildWatcher(['./source/**/*.scss'], 'scss:process', true));
       options.files.push(buildWatcher(['./source/templates/**/*.jade'], 'jade:process'));


### PR DESCRIPTION
Убрал строку, которая формирует вотчер для изображений с таском, который не существует. Сейчас вместо copy:image полноценно работает copy:resourse, поэтому добавлять таск под картинки не стал. Заметил баг, т.к. при создании в папке исходников папки images галп падает при любом дергании этой папки.
